### PR TITLE
Improve test speed

### DIFF
--- a/server/internal/jwt/jwt_test.go
+++ b/server/internal/jwt/jwt_test.go
@@ -30,11 +30,25 @@ type test struct {
 }
 
 func TestSignAndValidate(t *testing.T) {
+	keys := [][]keyPair{
+		{
+			generateKeys(t, 1000),
+			generateKeys(t, 1000),
+		},
+		{
+			generateKeys(t, 2048),
+			generateKeys(t, 2048),
+		},
+		{
+			generateKeys(t, 4096),
+			generateKeys(t, 4096),
+		},
+	}
 	tests := []test{
 		// Successful sign and validate
 		{
 			testName:        "valid 1",
-			keys:            generateKeys(t, 1000),
+			keys:            keys[0][0],
 			signerIssuer:    "kript.api",
 			validatorIssuer: "kript.api",
 			userID:          "user123",
@@ -46,7 +60,7 @@ func TestSignAndValidate(t *testing.T) {
 		},
 		{
 			testName:        "valid 2",
-			keys:            generateKeys(t, 1024),
+			keys:            keys[1][0],
 			signerIssuer:    "issuer",
 			validatorIssuer: "issuer",
 			userID:          "other user",
@@ -58,24 +72,12 @@ func TestSignAndValidate(t *testing.T) {
 		},
 		{
 			testName:        "valid 3",
-			keys:            generateKeys(t, 2312),
+			keys:            keys[1][0],
 			signerIssuer:    "reuonewrci",
 			validatorIssuer: "reuonewrci",
 			userID:          "thisisauserid-1234567890",
 			tokenType:       "validate",
 			expireTime:      time.Now().Add(time.Nanosecond * 1000000000000000),
-			validPublicKey:  true,
-			validPrivateKey: true,
-			validJWT:        true,
-		},
-		{
-			testName:        "valid 4",
-			keys:            generateKeys(t, 4096),
-			signerIssuer:    "eiownx43nx9re0jx9",
-			validatorIssuer: "eiownx43nx9re0jx9",
-			userID:          "ecuinjekckjd",
-			tokenType:       "aybdssahdjqd",
-			expireTime:      time.Now().Add(time.Minute),
 			validPublicKey:  true,
 			validPrivateKey: true,
 			validJWT:        true,
@@ -89,25 +91,25 @@ func TestSignAndValidate(t *testing.T) {
 		},
 		{
 			testName:        "invalid key 2",
-			keys:            keyPair{generateKeys(t, 512).public, nil},
+			keys:            keyPair{keys[0][0].public, nil},
 			validPublicKey:  true,
 			validPrivateKey: false,
 		},
 		{
 			testName:        "invalid key 3",
-			keys:            keyPair{nil, generateKeys(t, 512).private},
+			keys:            keyPair{nil, keys[0][0].private},
 			validPublicKey:  false,
 			validPrivateKey: true,
 		},
 		{
 			testName:        "invalid key 4",
-			keys:            keyPair{generateKeys(t, 4096).public, nil},
+			keys:            keyPair{keys[2][0].public, nil},
 			validPublicKey:  true,
 			validPrivateKey: false,
 		},
 		{
 			testName:        "invalid key 5",
-			keys:            keyPair{nil, generateKeys(t, 4096).private},
+			keys:            keyPair{nil, keys[2][0].private},
 			validPublicKey:  false,
 			validPrivateKey: true,
 		},
@@ -120,8 +122,8 @@ func TestSignAndValidate(t *testing.T) {
 		{
 			testName: "invalid key 7",
 			keys: keyPair{
-				public:  randomBytes(t, len(generateKeys(t, 512).public)),
-				private: randomBytes(t, len(generateKeys(t, 512).private)),
+				public:  randomBytes(t, len(keys[0][0].public)),
+				private: randomBytes(t, len(keys[0][0].private)),
 			},
 			validPublicKey:  false,
 			validPrivateKey: false,
@@ -129,7 +131,7 @@ func TestSignAndValidate(t *testing.T) {
 		// Invalid signing (non-corresponding keys)
 		{
 			testName:        "invalid key pair 1",
-			keys:            keyPair{generateKeys(t, 2048).public, generateKeys(t, 2048).private},
+			keys:            keyPair{keys[0][0].public, keys[0][1].private},
 			signerIssuer:    "kript.api",
 			validatorIssuer: "kript.api",
 			userID:          "user123",
@@ -141,7 +143,7 @@ func TestSignAndValidate(t *testing.T) {
 		},
 		{
 			testName:        "invalid key pair 2",
-			keys:            keyPair{generateKeys(t, 1024).public, generateKeys(t, 1024).private},
+			keys:            keyPair{keys[1][0].public, keys[1][1].private},
 			signerIssuer:    "issuer",
 			validatorIssuer: "issuer",
 			userID:          "other user",
@@ -153,7 +155,7 @@ func TestSignAndValidate(t *testing.T) {
 		},
 		{
 			testName:        "invalid key pair 3",
-			keys:            keyPair{generateKeys(t, 2312).public, generateKeys(t, 2312).private},
+			keys:            keyPair{keys[2][0].public, keys[2][1].private},
 			signerIssuer:    "reuonewrci",
 			validatorIssuer: "reuonewrci",
 			userID:          "thisisauserid-1234567890",
@@ -163,22 +165,10 @@ func TestSignAndValidate(t *testing.T) {
 			validPrivateKey: true,
 			validJWT:        false,
 		},
-		{
-			testName:        "invalid key pair 4",
-			keys:            keyPair{generateKeys(t, 4096).public, generateKeys(t, 4096).private},
-			signerIssuer:    "eiownx43nx9re0jx9",
-			validatorIssuer: "eiownx43nx9re0jx9",
-			userID:          "ecuinjekckjd",
-			tokenType:       "aybdssahdjqd",
-			expireTime:      time.Now().Add(time.Minute),
-			validPublicKey:  true,
-			validPrivateKey: true,
-			validJWT:        false,
-		},
 		// Wrong issuer (issuers don't match)
 		{
 			testName:        "invalid issuer",
-			keys:            generateKeys(t, 4096),
+			keys:            keys[2][0],
 			signerIssuer:    "kript.api",
 			validatorIssuer: "kript.ipa",
 			userID:          "user123",
@@ -191,19 +181,19 @@ func TestSignAndValidate(t *testing.T) {
 		// Expired token
 		{
 			testName:        "expired token 1",
-			keys:            generateKeys(t, 4096),
+			keys:            keys[2][0],
 			signerIssuer:    "kript.api",
 			validatorIssuer: "kript.api",
 			userID:          "user123",
 			tokenType:       "access",
-			expireTime:      time.Now().Add(-time.Microsecond),
+			expireTime:      time.Now().Add(-2 * time.Second),
 			validPublicKey:  true,
 			validPrivateKey: true,
 			validJWT:        false,
 		},
 		{
 			testName:        "expired token 2",
-			keys:            generateKeys(t, 4096),
+			keys:            keys[2][1],
 			signerIssuer:    "kript.api",
 			validatorIssuer: "kript.api",
 			userID:          "user123",

--- a/server/internal/jwt/validate.go
+++ b/server/internal/jwt/validate.go
@@ -6,7 +6,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"github.com/dgrijalva/jwt-go"
-	"time"
 )
 
 type Validator struct {
@@ -35,7 +34,7 @@ func NewValidator(publicKey []byte, issuerId string) (*Validator, error) {
 
 func (v *Validator) ValidateJWT(tokenString string) (user string, tokenType string, err error) {
 	claims := &jwt.StandardClaims{}
-	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+	_, err = jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
@@ -44,12 +43,8 @@ func (v *Validator) ValidateJWT(tokenString string) (user string, tokenType stri
 	})
 	if err != nil {
 		return "", "", err
-	} else if !token.Valid {
-		return "", "", err
 	} else if claims.Issuer != v.issuerId {
 		return "", "", fmt.Errorf("invalid issuer: %s", claims.Issuer)
-	} else if claims.ExpiresAt < time.Now().Unix() {
-		return "", "", fmt.Errorf("expired at: %v", claims.ExpiresAt)
 	}
 
 	return claims.Subject, claims.Audience, nil


### PR DESCRIPTION
Improve JWT test speed by reducing the number of key generations.